### PR TITLE
Make homehost=any

### DIFF
--- a/partition-disks.sh
+++ b/partition-disks.sh
@@ -3,7 +3,6 @@
 DISK1="vda"
 DISK2="vdb"
 KEYMAP="de-latin1"
-HOSTNAME="tux-stellaris-15"
 OLD_LUKS="md0_crypt"
 OLD_MDADM="md0"
 
@@ -25,7 +24,7 @@ sgdisk -n 0:0:0 -t 1:fd00 /dev/"$DISK1"
 sgdisk -n 0:0:0 -t 1:fd00 /dev/"$DISK2"
 mkfs.fat -n BOOT -F32 /dev/"$DISK1"1
 mkfs.fat -n BOOT -F32 /dev/"$DISK2"1
-mdadm --create --verbose --level=1 --metadata=1.2 --raid-devices=2 --homehost="$HOSTNAME" /dev/md/md0 /dev/"$DISK1"2 /dev/"$DISK2"2
+mdadm --create --verbose --level=1 --metadata=1.2 --raid-devices=2 --homehost=any /dev/md/md0 /dev/"$DISK1"2 /dev/"$DISK2"2
 cryptsetup open --type plain -d /dev/urandom /dev/md/md0 to_be_wiped
 cryptsetup close to_be_wiped
 cryptsetup -y -v -h sha512 -s 512 luksFormat /dev/md/md0


### PR DESCRIPTION
This may fix the boot issue.
My theory is that after grub accepting the password it loads the hostname and thus the device is renamed to md0.
Therefore, this should solve that issue if it even is an issue because now md0 is always md0